### PR TITLE
fix url field is invalid link

### DIFF
--- a/vpm.json
+++ b/vpm.json
@@ -2,7 +2,7 @@
   "name": "The 53 Labs vpm",
   "id": "io.github.sonic853.vpm",
   "author": "Sonic853",
-  "url": "https://853.moe/vpm-repos/vpm.json",
+  "url": "https://page.853lab.com/vpm.json",
   "packages": {
     "com.foorack.udonzip": {
       "versions": {


### PR DESCRIPTION
This pr fixes url field on vpm repository is invalid.

I found this during testing my vpm client so I made pull request.